### PR TITLE
[Jenkinsfile] Added ‘version’ field for p2p artifacts on kurjun #253

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,7 +111,7 @@ try {
 		/* get p2p version */
 		String p2pVersion = sh (script: """
 			set +x
-			./p2p version | cut -d " " -f 4
+			./p2p version | cut -d " " -f 4 | tr -d '\n'
 			""", returnStdout: true)
 		if (suffix != '') {
 			sh """


### PR DESCRIPTION
Trim ‘p2p version’ output