### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PACK=goupx
 VERSION=$(shell git describe)
 OS=$(shell uname -s)
 ARCH=$(shell uname -m)
-NAME_PERFIX=p2p
+NAME_PREFIX=p2p
 NAME_BASE=p2p
 sinclude config.make
 APP=$(NAME_BASE)


### PR DESCRIPTION
```
$ make clean
rm -f p2p
rm -f p2p_osx
rm -f p2p.exe
rm -f p2p-Linux*
rm -f
rm -f _osx
rm -f .exe
rm -f -Linux*
rm: invalid option -- 'L'
Try 'rm --help' for more information.
Makefile:40: recipe for target 'clean' failed
make: [clean] Error 1 (ignored)
```