### PR TITLE
Added build id to debug output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=go
 PACK=goupx
-#VERSION=$(shell git describe)
+BUILD=$(shell git describe)
 VERSION=$(shell cat VERSION)
 OS=$(shell uname -s)
 ARCH=$(shell uname -m)
@@ -35,15 +35,15 @@ all: linux windows macos
 
 $(APP): help.go instance.go main.go rest.go
 	@if [ ! -d "$(GOPATH)/src/github.com/subutai-io/p2p" ]; then mkdir -p $(GOPATH)/src/github.com/subutai-io/; ln -s $(shell pwd) $(GOPATH)/src/github.com/subutai-io/p2p; fi
-	$(CC) build -ldflags="-w -s -X main.AppVersion=$(VERSION) -X main.DefaultDHT=$(DHT)" -o $@ -v $^
+	$(CC) build -ldflags="-w -s -X main.AppVersion=$(VERSION) -X main.DefaultDHT=$(DHT) -X main.BuildID=$(BUILD)" -o $@ -v $^
 
 $(APP).exe:
 	@if [ ! -d "$(GOPATH)/src/github.com/subutai-io/p2p" ]; then mkdir -p $(GOPATH)/src/github.com/subutai-io/; ln -s $(shell pwd) $(GOPATH)/src/github.com/subutai-io/p2p; fi
-	GOOS=windows $(CC) build -ldflags="-w -s -X main.AppVersion=$(VERSION) -X main.DefaultDHT=$(DHT)" -o $@ -v $^
+	GOOS=windows $(CC) build -ldflags="-w -s -X main.AppVersion=$(VERSION) -X main.DefaultDHT=$(DHT) -X main.BuildID=$(BUILD)" -o $@ -v $^
 	
 $(APP)_osx:
 	@if [ ! -d "$(GOPATH)/src/github.com/subutai-io/p2p" ]; then mkdir -p $(GOPATH)/src/github.com/subutai-io/; ln -s $(shell pwd) $(GOPATH)/src/github.com/subutai-io/p2p; fi
-	GOOS=darwin $(CC) build -ldflags="-w -s -X main.AppVersion=$(VERSION) -X main.DefaultDHT=$(DHT)" -o $@ -v $^
+	GOOS=darwin $(CC) build -ldflags="-w -s -X main.AppVersion=$(VERSION) -X main.DefaultDHT=$(DHT) -X main.BuildID=$(BUILD)" -o $@ -v $^
 
 ifdef UPX_BIN
 pack: $(APP)
@@ -102,4 +102,4 @@ snapcraft: help.go instance.go main.go rest.go
 	$(eval export GOBIN=$(shell pwd)/../go/bin)
 	@if [ ! -d "$(GOPATH)/src/github.com/subutai-io/p2p" ]; then mkdir -p $(GOPATH)/src/github.com/subutai-io/; ln -s $(shell pwd) $(GOPATH)/src/github.com/subutai-io/p2p; fi
 	$(CC) get -d
-	$(CC) build -ldflags="-r /apps/subutai/current/lib -w -s -X main.AppVersion=$(VERSION) -X main.DefaultDHT=$(DHT)" -o $(APP) -v $^
+	$(CC) build -ldflags="-r /apps/subutai/current/lib -w -s -X main.AppVersion=$(VERSION) -X main.DefaultDHT=$(DHT) -X main.BuildID=$(BUILD)" -o $(APP) -v $^

--- a/instance.go
+++ b/instance.go
@@ -430,7 +430,7 @@ func (p *Daemon) Show(args *ShowArgs, resp *Response) error {
 func (p *Daemon) Debug(args *Args, resp *Response) error {
 	ptp.Log(ptp.Info, "Preparing Debug output")
 	resp.Output = "DEBUG INFO:\n"
-	resp.Output = fmt.Sprintf("Version: %s\n", AppVersion)
+	resp.Output = fmt.Sprintf("Version: %s Build: %s\n", AppVersion, BuildID)
 	resp.Output += fmt.Sprintf("Number of gouroutines: %d\n", runtime.NumGoroutine())
 	resp.Output += fmt.Sprintf("Instances information:\n")
 	instances := p.Instances.Get()

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 
 // AppVersion is a Version of P2P
 var AppVersion = "Unknown"
+var BuildID = "Unknown"
 var DefaultDHT = "mdht.subut.ai:6881"
 
 // InterfaceNames - List of all interfaces names that was used by p2p historically. These interfaces may not present in the system anymore
@@ -656,7 +657,7 @@ func sendRequest(port int, command string, args *DaemonArgs) (*RESTResponse, err
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to send request: %s", err)
+		return nil, fmt.Errorf("Couldn't execute command. Check if p2p daemon is running.")
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
Now executing `p2p debug` will show Build ID, which is
`git describe` output for now
  