### PR TITLE
Changed Slack Token ID

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -303,7 +303,7 @@ def notifyBuild(String buildStatus = 'STARTED', String details = '') {
 	summary = "${subject} (${env.BUILD_URL})${details}"
   }
   // Get token
-  def slackToken = getSlackToken('sysnet')
+  def slackToken = getSlackToken('p2p-bots')
   // Send notifications
   slackSend (color: colorCode, message: summary, teamDomain: 'optdyn', token: "${slackToken}")
 }


### PR DESCRIPTION
Now p2p builds should go to #p2p-bots channel