### PR TITLE
Sysnet

### DIFF
--- a/lib/dht_callbacks.go
+++ b/lib/dht_callbacks.go
@@ -267,15 +267,15 @@ func (p *PeerToPeer) packetRequestProxy(packet *DHTPacket) error {
 		list = append(list, addr)
 	}
 
-	peers := p.Peers.Get()
-	for _, proxy := range list {
-		for _, existingPeer := range peers {
-			if existingPeer.Endpoint.String() == proxy.String() && existingPeer.ID != packet.Data {
-				existingPeer.SetState(PeerStateDisconnect, p)
-				Log(Info, "Peer %s was associated with address %s. Disconnecting", existingPeer.ID, proxy.String())
-			}
-		}
-	}
+	// peers := p.Peers.Get()
+	// for _, proxy := range list {
+	// 	for _, existingPeer := range peers {
+	// 		if existingPeer.Endpoint.String() == proxy.String() && existingPeer.ID != packet.Data {
+	// 			existingPeer.SetState(PeerStateDisconnect, p)
+	// 			Log(Info, "Peer %s was associated with address %s. Disconnecting", existingPeer.ID, proxy.String())
+	// 		}
+	// 	}
+	// }
 
 	peer := p.Peers.GetPeer(packet.Data)
 	if peer != nil {

--- a/lib/p2p.go
+++ b/lib/p2p.go
@@ -447,18 +447,6 @@ func (p *PeerToPeer) ReportIP(ipAddress, mac, device string) (net.IP, net.IPMask
 	return ip, ipnet.Mask, nil
 }
 
-// TODO: Check if this method is still used
-func (p *PeerToPeer) markPeerForRemoval(id, reason string) error {
-	peer := p.Peers.GetPeer(id)
-	if peer == nil {
-		return fmt.Errorf("Peer was not found")
-	}
-	Log(Debug, "Removing peer %s: Reason %s", id, reason)
-	peer.SetState(PeerStateDisconnect, p)
-	p.Peers.Update(id, peer)
-	return nil
-}
-
 // Run is a main loop
 func (p *PeerToPeer) Run() {
 	// Request proxies from DHT

--- a/lib/peer.go
+++ b/lib/peer.go
@@ -420,6 +420,9 @@ func (np *NetworkPeer) route(ptpc *PeerToPeer) error {
 		// 		np.SetState(PeerStateRequestingProxy, ptpc)
 		// 		return nil
 		// 	}
+	} else {
+		np.Endpoint = nil
+		np.SetState(PeerStateDisconnect, ptpc)
 	}
 	return nil
 }
@@ -427,6 +430,9 @@ func (np *NetworkPeer) route(ptpc *PeerToPeer) error {
 // stateConnected is executed when connection was established and peer is operating normally
 func (np *NetworkPeer) stateConnected(ptpc *PeerToPeer) error {
 	np.route(ptpc)
+	if np.State != PeerStateConnected {
+		return nil
+	}
 
 	// if time.Since(np.LastPunch) > time.Duration(time.Millisecond*30000) && np.Stat.localNum < 1 && np.Stat.internetNum < 1 {
 	// 	Log(Info, "New hole punch activity: Local %d Internet %d", np.Stat.localNum, np.Stat.internetNum)
@@ -436,10 +442,10 @@ func (np *NetworkPeer) stateConnected(ptpc *PeerToPeer) error {
 	np.pingEndpoints(ptpc)
 	np.syncWithRemoteState(ptpc)
 
-	if time.Since(np.LastFind) > time.Duration(time.Second*90) {
-		Log(Debug, "No endpoints and no updates from DHT")
-		np.SetState(PeerStateDisconnect, ptpc)
-	}
+	// if time.Since(np.LastFind) > time.Duration(time.Second*90) {
+	// 	Log(Debug, "No endpoints and no updates from DHT")
+	// 	np.SetState(PeerStateDisconnect, ptpc)
+	// }
 
 	return nil
 }


### PR DESCRIPTION
Removed state switch on proxy list arrival
Removed unused method that was switching peer state
More strict disconnect policy added
Peer will disconnect after it looses all endpoints