### PR TITLE
systemd: call cop on failure

### DIFF
--- a/debian/subutai-p2p.service
+++ b/debian/subutai-p2p.service
@@ -6,6 +6,7 @@ Type=simple
 EnvironmentFile=-/etc/default/subutai-p2p
 ExecStart=/usr/bin/p2p daemon -save /var/lib/subutai/data/p2p.save -syslog 127.0.0.1:1514 --mtu=${P2P_MTU}
 Restart=always
+OnFailure=subutai-cop.service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This change makes systemd to run `subutai-cop.service` when the p2p service is put to `failed` state. After all th automatic restart attempts by systemd itself are failed, the cop is called to rescue.

Cop is located in agent repository and is added to `subutai` package.