### PR TITLE
Added `version` CLI command

### DIFF
--- a/main.go
+++ b/main.go
@@ -435,6 +435,14 @@ func main() {
 				return nil
 			},
 		},
+		{
+			Name:  "version",
+			Usage: "Display version number",
+			Action: func(c *cli.Context) error {
+				fmt.Println(AppVersion)
+				return nil
+			},
+		},
 	}
 	app.Run(os.Args)
 }


### PR DESCRIPTION
New `version` CLI command that displays version number.
Previous `-v` is also working, but shows more detailed information