### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/lib/log.go
+++ b/lib/log.go
@@ -39,7 +39,7 @@ func SetMinLogLevel(level LogLevel) {
 	logLevelMin = level
 }
 
-// SetMinLogLevel sets a minimal logging level. Accepts a string for setting
+// SetMinLogLevelString sets a minimal logging level. Accepts a string for setting
 func SetMinLogLevelString(level string) error {
 	level = strings.ToLower(level)
 	if level == "trace" {


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?